### PR TITLE
Add recall estimation feature to CLI, exporter, and dashboard

### DIFF
--- a/grafana/dashboards/turbopuffer-overview.json
+++ b/grafana/dashboards/turbopuffer-overview.json
@@ -359,11 +359,11 @@
               },
               {
                 "color": "yellow",
-                "value": 95
+                "value": 80
               },
               {
                 "color": "green",
-                "value": 99
+                "value": 95
               }
             ]
           },
@@ -399,13 +399,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "(count(turbopuffer_namespace_rows{region=~\"$region\", namespace=~\"$namespace\", index_status=\"up-to-date\"}) / count(turbopuffer_namespace_rows{region=~\"$region\", namespace=~\"$namespace\"})) * 100 or vector(100)",
+          "expr": "avg(turbopuffer_namespace_recall{region=~\"$region\", namespace=~\"$namespace\"}) * 100 or vector(0)",
           "instant": true,
           "refId": "A"
         }
       ],
-      "title": "Index Health Percentage",
-      "description": "Percentage of namespaces with up-to-date indexes. Target: >95%",
+      "title": "Average Recall",
+      "description": "Average vector recall across namespaces. Target: >95%",
       "type": "gauge"
     },
     {


### PR DESCRIPTION
- Add --recall flag to list command for opt-in recall estimation
- Automatically include recall when using --all (multi-region) flag
- Add recall column with color-coded percentages (red ≤80%, yellow >80%, green >95%)
- Export recall metrics in Prometheus exporter as turbopuffer_namespace_recall
- Replace "Index Health Percentage" gauge with "Average Recall" gauge in Grafana dashboard
- Fetch recall data in parallel with metadata to minimize performance impact
- Use defaults: num=25, top_k=10 for recall API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)